### PR TITLE
Logging w/ conditional compilation for debug

### DIFF
--- a/src/ekko.rs
+++ b/src/ekko.rs
@@ -105,7 +105,6 @@ pub fn ekko(sleep_time: u32, key_buf: &mut Vec<u8>) {
     log::debug!("[+] WaitForSingleObject: {:#x}", wait_for_single_object);
     log::debug!("[+] SetEvent: {:#x}", set_event);
 
-    pause();
     log::debug!("[+] Calling CreateTimerQueueTimer with ctx_thread");
 
     // Contains processor-specific register data. The system uses CONTEXT structures to perform various internal operations.
@@ -213,6 +212,7 @@ fn get_input() -> std::io::Result<()> {
     Ok(())
 }
 
+#[allow(dead_code)]
 /// Used for debugging
 pub fn pause() {
     if cfg!(debug_assertions) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,14 @@
 mod ekko;
 
 fn main() {
-    //env_logger::init();
+    //
+    // Enable logging when debugging.
+    //
+    if cfg!(debug_assertions) {
+        std::env::set_var("RUST_LOG", "debug");
+        env_logger::init();
+    }
+    
     println!("[*] Ekko Sleep Obfuscation by @memN0ps and @trickster0. Full credits to Cracked5pider (@C5pider), Austin Hudson (@SecIdiot), Peter Winter-Smith (@peterwintrsmith)");
     
     let mut key_buf = "1234567890ABCDEF\0".as_bytes().to_vec();


### PR DESCRIPTION
Use if statement with `cfg` attribute for debugging output only when compiled with` debug` target. When compiling in `release` target, the `log::debug` will be skipped and the block within the if statement as well. Additionally, set the `RUST_LOG` environment variable at runtime.